### PR TITLE
Discard master-slave words

### DIFF
--- a/iaer/migrations/0001_initial.py
+++ b/iaer/migrations/0001_initial.py
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
             name='User',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_master_user', models.BooleanField(default=False)),
+                ('is_main_user', models.BooleanField(default=False)),
                 ('phone', models.CharField(blank=True, max_length=30, null=True)),
                 ('gender', models.PositiveSmallIntegerField(default=2)),
                 ('profile', models.CharField(blank=True, max_length=200, null=True)),
@@ -124,7 +124,7 @@ class Migration(migrations.Migration):
                 ('is_phone_activate', models.BooleanField(default=False)),
                 ('auth_user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='uss', to=settings.AUTH_USER_MODEL)),
                 ('fund', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='iaer.Fund')),
-                ('slave_user', models.ManyToManyField(blank=True, related_name='_user_slave_user_+', to='iaer.User')),
+                ('subordinate_user', models.ManyToManyField(blank=True, related_name='_user_subordinate_user_+', to='iaer.User')),
             ],
         ),
         migrations.CreateModel(

--- a/iaer/models.py
+++ b/iaer/models.py
@@ -63,8 +63,8 @@ class Fund(models.Model):
 
 class User(models.Model):
     auth_user = models.OneToOneField('auth.User', related_name='uss', on_delete=models.CASCADE)
-    is_master_user = models.BooleanField(default=False)
-    slave_user = models.ManyToManyField('self', blank=True)
+    is_main_user = models.BooleanField(default=False)
+    subordinate_user = models.ManyToManyField('self', blank=True)
     fund = models.ForeignKey(Fund, blank=True, null=True, on_delete=models.CASCADE)
     phone = models.CharField(max_length=30, blank=True, null=True)
     gender = models.PositiveSmallIntegerField(default=2) #0 for boy, 1 for girl, 2 for others


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.